### PR TITLE
Google Initialization and Deployment Improvements

### DIFF
--- a/scripts/google_init.sh
+++ b/scripts/google_init.sh
@@ -22,7 +22,7 @@ if ! [ -x "$(command -v kubectl)" ]; then
 fi
 
 gcloud organizations list && \
-read -p "Google Cloud Organization ID: " ORG_ID && \
+read -p "Google Cloud Organization ID (leave empty to create project without organization): " ORG_ID && \
 
 gcloud beta billing accounts list && \
 read -p "Google Cloud Billing ACCOUNT_ID: " BILLING_ID && \
@@ -37,10 +37,15 @@ BQ_LOCATION=EU
 ZONE=europe-west1-b
 
 ### create project
-echo "create project ..." && \
-gcloud projects create ${GC_PROJECT_ID} \
-  --organization ${ORG_ID} \
-  --set-as-default && \
+echo "create project ..."
+if [-z '$ORG_ID']; then
+  gcloud projects create ${GC_PROJECT_ID} \
+    --set-as-default
+else
+  gcloud projects create ${GC_PROJECT_ID} \
+    --organization ${ORG_ID} \
+    --set-as-default
+fi
 
 gcloud beta billing projects link ${GC_PROJECT_ID} \
   --billing-account ${BILLING_ID} && \

--- a/scripts/google_init.sh
+++ b/scripts/google_init.sh
@@ -38,7 +38,7 @@ ZONE=europe-west1-b
 
 ### create project
 echo "create project ..."
-if [-z '$ORG_ID']; then
+if [[ -z '$ORG_ID' ]]; then
   gcloud projects create ${GC_PROJECT_ID} \
     --set-as-default
 else

--- a/scripts/google_init.sh
+++ b/scripts/google_init.sh
@@ -159,6 +159,8 @@ BUCKET_NAME=${BUCKET_NAME%dags}
 
 bash google_deploy.sh && \
 
-gsutil -m cp -r ../google_deploy/* ${BUCKET_NAME} 
+gsutil -m cp -r ../google_deploy/* ${BUCKET_NAME}
+
+echo "your premium league environment is now ready and its project id is: ${GC_PROJECT_ID}"
 
 popd >/dev/null 2>&1

--- a/scripts/google_init.sh
+++ b/scripts/google_init.sh
@@ -38,7 +38,7 @@ ZONE=europe-west1-b
 
 ### create project
 echo "create project ..."
-if [[ -z '$ORG_ID' ]]; then
+if [[ -z '$ORG_ID' || ${ORG_ID}=='' ]]; then
   gcloud projects create ${GC_PROJECT_ID} \
     --set-as-default
 else

--- a/scripts/google_upload_data.sh
+++ b/scripts/google_upload_data.sh
@@ -2,6 +2,8 @@
 
 pushd $( dirname "${BASH_SOURCE[0]}" ) >/dev/null 2>&1
 
+read -p "please enter your project id: " GC_PROJECT_ID
+
 gsutil -m cp ../data/matchweek/* gs://${GC_PROJECT_ID} && \
 gsutil -m cp ../data/scorer/* gs://${GC_PROJECT_ID}
 


### PR DESCRIPTION
This PR makes...
* the GC organization optional; users can leave it empty when running `google_init.sh` to create the project without an organization
* pretty echo the project id after completion of the `google_init.sh` script
* the `google_upload_data.sh` script ask for the project id to be entered by the user